### PR TITLE
UI fixes

### DIFF
--- a/CanadianTides.fbp
+++ b/CanadianTides.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="15" />
+    <FileVersion major="1" minor="16" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">C++</property>
@@ -14,6 +14,7 @@
         <property name="file">CanadianTidesgui</property>
         <property name="first_id">1000</property>
         <property name="help_provider">none</property>
+        <property name="image_path_wrapper_function_name"></property>
         <property name="indent_with_spaces"></property>
         <property name="internationalize">1</property>
         <property name="name">CanadianTides_pi</property>
@@ -25,19 +26,20 @@
         <property name="skip_php_events">1</property>
         <property name="skip_python_events">1</property>
         <property name="ui_table">UI</property>
+        <property name="use_array_enum">0</property>
         <property name="use_enum">0</property>
         <property name="use_microsoft_bom">0</property>
         <object class="Frame" expanded="1">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
-            <property name="bg">255,255,255</property>
+            <property name="bg">wxSYS_COLOUR_WINDOW</property>
             <property name="center">wxBOTH</property>
             <property name="context_help"></property>
             <property name="context_menu">1</property>
             <property name="enabled">1</property>
             <property name="event_handler">impl_virtual</property>
             <property name="extra_style"></property>
-            <property name="fg">0,0,0</property>
+            <property name="fg">wxSYS_COLOUR_WINDOW</property>
             <property name="font"></property>
             <property name="hidden">0</property>
             <property name="id">wxID_ANY</property>
@@ -50,6 +52,7 @@
             <property name="subclass">; ; forward_declare</property>
             <property name="title">CA Tides</property>
             <property name="tooltip"></property>
+            <property name="two_step_creation">0</property>
             <property name="window_extra_style"></property>
             <property name="window_name"></property>
             <property name="window_style">wxTAB_TRAVERSAL</property>
@@ -60,11 +63,11 @@
                 <property name="name">bSizerMain</property>
                 <property name="orient">wxVERTICAL</property>
                 <property name="permission">none</property>
-                <object class="sizeritem" expanded="0">
+                <object class="sizeritem" expanded="1">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND</property>
                     <property name="proportion">0</property>
-                    <object class="wxStaticBoxSizer" expanded="0">
+                    <object class="wxStaticBoxSizer" expanded="1">
                         <property name="id">wxID_ANY</property>
                         <property name="label">Important</property>
                         <property name="minimum_size"></property>
@@ -98,9 +101,9 @@
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
                                 <property name="enabled">1</property>
-                                <property name="fg"></property>
+                                <property name="fg">wxSYS_COLOUR_WINDOWTEXT</property>
                                 <property name="floatable">1</property>
-                                <property name="font">Arial,90,92,12,74,0</property>
+                                <property name="font">Arial,90,700,12,74,0</property>
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
@@ -135,11 +138,11 @@
                         </object>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="0">
+                <object class="sizeritem" expanded="1">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND</property>
                     <property name="proportion">1</property>
-                    <object class="wxBoxSizer" expanded="0">
+                    <object class="wxBoxSizer" expanded="1">
                         <property name="minimum_size"></property>
                         <property name="name">bSizer5</property>
                         <property name="orient">wxHORIZONTAL</property>
@@ -170,7 +173,7 @@
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
                                 <property name="enabled">1</property>
-                                <property name="fg"></property>
+                                <property name="fg">wxSYS_COLOUR_WINDOWTEXT</property>
                                 <property name="floatable">1</property>
                                 <property name="font"></property>
                                 <property name="gripper">0</property>
@@ -318,7 +321,7 @@
                                         <property name="dock_fixed">0</property>
                                         <property name="docking">Left</property>
                                         <property name="enabled">1</property>
-                                        <property name="fg"></property>
+                                        <property name="fg">wxSYS_COLOUR_WINDOWTEXT</property>
                                         <property name="floatable">1</property>
                                         <property name="font"></property>
                                         <property name="gripper">0</property>
@@ -380,7 +383,7 @@
                                         <property name="dock_fixed">0</property>
                                         <property name="docking">Left</property>
                                         <property name="enabled">1</property>
-                                        <property name="fg"></property>
+                                        <property name="fg">wxSYS_COLOUR_WINDOW</property>
                                         <property name="floatable">1</property>
                                         <property name="font"></property>
                                         <property name="gripper">0</property>
@@ -490,6 +493,7 @@
                                 <property name="aui_name"></property>
                                 <property name="aui_position"></property>
                                 <property name="aui_row"></property>
+                                <property name="auth_needed">0</property>
                                 <property name="best_size"></property>
                                 <property name="bg"></property>
                                 <property name="bitmap"></property>
@@ -576,7 +580,7 @@
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
                                 <property name="enabled">1</property>
-                                <property name="fg"></property>
+                                <property name="fg">wxSYS_COLOUR_WINDOWTEXT</property>
                                 <property name="floatable">1</property>
                                 <property name="font"></property>
                                 <property name="gripper">0</property>
@@ -624,6 +628,7 @@
                                 <property name="aui_name"></property>
                                 <property name="aui_position"></property>
                                 <property name="aui_row"></property>
+                                <property name="auth_needed">0</property>
                                 <property name="best_size"></property>
                                 <property name="bg"></property>
                                 <property name="bitmap"></property>
@@ -697,6 +702,7 @@
                                 <property name="aui_name"></property>
                                 <property name="aui_position"></property>
                                 <property name="aui_row"></property>
+                                <property name="auth_needed">0</property>
                                 <property name="best_size"></property>
                                 <property name="bg"></property>
                                 <property name="bitmap"></property>
@@ -770,6 +776,7 @@
                                 <property name="aui_name"></property>
                                 <property name="aui_position"></property>
                                 <property name="aui_row"></property>
+                                <property name="auth_needed">0</property>
                                 <property name="best_size"></property>
                                 <property name="bg"></property>
                                 <property name="bitmap"></property>

--- a/CanadianTides.fbp
+++ b/CanadianTides.fbp
@@ -77,7 +77,7 @@
                         <property name="permission">none</property>
                         <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND</property>
+                            <property name="flag">wxALL|wxEXPAND</property>
                             <property name="proportion">0</property>
                             <object class="wxStaticText" expanded="0">
                                 <property name="BottomDockable">1</property>

--- a/src/CanadianTidesgui.cpp
+++ b/src/CanadianTidesgui.cpp
@@ -26,7 +26,7 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 	m_stTimeZone->SetFont( wxFont( 12, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxT("Arial") ) );
 	m_stTimeZone->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT ) );
 
-	sbSizerDateTime->Add( m_stTimeZone, 0, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
+	sbSizerDateTime->Add( m_stTimeZone, 0, wxALL|wxEXPAND, 5 );
 
 
 	bSizerMain->Add( sbSizerDateTime, 0, wxEXPAND, 5 );

--- a/src/CanadianTidesgui.cpp
+++ b/src/CanadianTidesgui.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct 26 2018)
+// C++ code generated with wxFormBuilder (version 3.10.1-0-g8feb16b)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -12,8 +12,8 @@
 DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxFrame( parent, id, title, pos, size, style )
 {
 	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	this->SetForegroundColour( wxColour( 0, 0, 0 ) );
-	this->SetBackgroundColour( wxColour( 255, 255, 255 ) );
+	this->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOW ) );
+	this->SetBackgroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOW ) );
 
 	wxBoxSizer* bSizerMain;
 	bSizerMain = new wxBoxSizer( wxVERTICAL );
@@ -24,6 +24,7 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 	m_stTimeZone = new wxStaticText( sbSizerDateTime->GetStaticBox(), wxID_ANY, _("All times UTC"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
 	m_stTimeZone->Wrap( -1 );
 	m_stTimeZone->SetFont( wxFont( 12, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxT("Arial") ) );
+	m_stTimeZone->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT ) );
 
 	sbSizerDateTime->Add( m_stTimeZone, 0, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5 );
 
@@ -35,6 +36,8 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 
 	m_staticText9 = new wxStaticText( this, wxID_ANY, _("Days ahead: "), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText9->Wrap( -1 );
+	m_staticText9->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT ) );
+
 	bSizer5->Add( m_staticText9, 0, wxALL, 5 );
 
 	wxString m_choice3Choices[] = { _("1"), _("2"), _("3"), _("4"), _("5"), _("6"), _("7") };
@@ -54,12 +57,16 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 
 	m_staticText91 = new wxStaticText( sbSizerFolder->GetStaticBox(), wxID_ANY, _("Region:       "), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText91->Wrap( -1 );
+	m_staticText91->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT ) );
+
 	bSizer3->Add( m_staticText91, 0, wxALL, 5 );
 
 	wxString m_choice31Choices[] = { _("PAC"), _("CNA"), _("ATL"), _("QUE") };
 	int m_choice31NChoices = sizeof( m_choice31Choices ) / sizeof( wxString );
 	m_choice31 = new wxChoice( sbSizerFolder->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choice31NChoices, m_choice31Choices, 0 );
 	m_choice31->SetSelection( 0 );
+	m_choice31->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOW ) );
+
 	bSizer3->Add( m_choice31, 0, wxALL, 5 );
 
 
@@ -73,6 +80,8 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 
 	m_stUKDownloadInfo = new wxStaticText( sbSizerFolder->GetStaticBox(), wxID_ANY, _("Status:   Standby"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_stUKDownloadInfo->Wrap( -1 );
+	m_stUKDownloadInfo->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT ) );
+
 	sbSizerFolder->Add( m_stUKDownloadInfo, 0, wxALL|wxEXPAND, 5 );
 
 	m_buttonSaved = new wxButton( sbSizerFolder->GetStaticBox(), wxID_ANY, _("Show Saved"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/CanadianTidesgui.h
+++ b/src/CanadianTidesgui.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct 26 2018)
+// C++ code generated with wxFormBuilder (version 3.10.1-0-g8feb16b)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -20,10 +20,10 @@
 #include <wx/statbox.h>
 #include <wx/choice.h>
 #include <wx/statline.h>
+#include <wx/button.h>
 #include <wx/bitmap.h>
 #include <wx/image.h>
 #include <wx/icon.h>
-#include <wx/button.h>
 #include <wx/frame.h>
 
 ///////////////////////////////////////////////////////////////////////////
@@ -43,7 +43,7 @@ class DlgDef : public wxFrame
 		wxChoice* m_choice31;
 		wxStaticLine* m_staticline2;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
 		virtual void OnDownload( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnGetSavedTides( wxCommandEvent& event ) { event.Skip(); }

--- a/src/CanadianTidesgui_impl.cpp
+++ b/src/CanadianTidesgui_impl.cpp
@@ -1267,14 +1267,11 @@ GetTidalEventDialog::GetTidalEventDialog(wxWindow * parent, wxWindowID id, const
 	itemBoxSizer1->Add(m_pListSizer, 2, wxEXPAND | wxALL, 1);
 
 	wxBoxSizer* itemBoxSizerBottom = new wxBoxSizer(wxHORIZONTAL);
-	itemBoxSizer1->Add(itemBoxSizerBottom, 0, wxALIGN_LEFT | wxALL | wxEXPAND, 5);
-
-	wxBoxSizer* itemBoxSizer16 = new wxBoxSizer(wxHORIZONTAL);
-	itemBoxSizerBottom->Add(itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 3);
+	itemBoxSizer1->Add(itemBoxSizerBottom, 0, wxALIGN_RIGHT | wxALL, 5);
 
 	m_OKButton = new wxButton(this, wxID_OK, _("OK"), wxDefaultPosition,
 		wxDefaultSize, 0);
-	itemBoxSizer16->Add(m_OKButton, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 1);
+	itemBoxSizerBottom->Add(m_OKButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 1);
 	m_OKButton->SetDefault();
 
 

--- a/src/tidetable.cpp
+++ b/src/tidetable.cpp
@@ -133,26 +133,23 @@ void TideTable::CreateControls()
 	m_pListSizer->Add(m_wpList, 1, wxEXPAND | wxALL, 6);
 
 	wxBoxSizer* itemBoxSizerBottom = new wxBoxSizer(wxHORIZONTAL);
-	itemBoxSizer1->Add(itemBoxSizerBottom, 0, wxALIGN_LEFT | wxALL | wxEXPAND, 5);
+	itemBoxSizer1->Add(itemBoxSizerBottom, 0, wxALL | wxALIGN_RIGHT, 5);
              
-      wxBoxSizer* itemBoxSizer16 = new wxBoxSizer( wxHORIZONTAL );
-      itemBoxSizerBottom->Add( itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 3 );
-      
       m_OKButton = new wxButton( this, ID_ROUTEPROP_OK, _("OK"), wxDefaultPosition,
       wxDefaultSize, 0 );
 
-      itemBoxSizer16->Add( m_OKButton, 0, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxALL, 1);
+      itemBoxSizerBottom->Add( m_OKButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 1);
       //m_OKButton->SetDefault();
 
 	  m_bDelete = new wxButton(this, ID_ROUTEPROP_DELETE, _("Delete"), wxDefaultPosition,
       wxDefaultSize, 0);
 
-	  itemBoxSizer16->Add(m_bDelete, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 1);
+	  itemBoxSizerBottom->Add(m_bDelete, 0, wxALIGN_CENTER_VERTICAL | wxALL, 1);
 
 	  m_bDeleteAll = new wxButton(this, ID_ROUTEPROP_DELETE_ALL, _("Delete ALL"), wxDefaultPosition,
 		  wxDefaultSize, 0);
 
-	  itemBoxSizer16->Add(m_bDeleteAll, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 1);
+	  itemBoxSizerBottom->Add(m_bDeleteAll, 0, wxALIGN_CENTER_VERTICAL | wxALL, 1);
 
       //      To correct a bug in MSW commctl32, we need to catch column width drag events, and do a Refresh()
       //      Otherwise, the column heading disappear.....


### PR DESCRIPTION
- Make the UI colors follow the system scheme (Makes the plugin usable with dark system themes)
- Fix WX asserts for invalid element positioning flags and slightly simplify the sizers
<img width="583" alt="Screen Shot 2022-03-11 at 11 54 40 AM" src="https://user-images.githubusercontent.com/249856/157891463-d79f7e2e-fba0-48f7-a107-252d211bb920.png">
.